### PR TITLE
Add PointCloud2 support, message restamping, multithreading, Go2 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,20 @@ This example is built for ROS 2. For more ROS examples, also check out the [ROS 
 The easiest way to get started is to install [pixi](https://prefix.dev/docs/pixi/overview).
 
 The pixi environment described in `pixi.toml` contains all required dependencies, including the example data, and the Rerun viewer. To run the [CARLA](https://carla.org/) example use
-
 ```shell
 pixi run carla_example
+```
+and to run the [Go2](https://www.unitree.com/go2/) example use
+```shell
+pixi run go2_example
 ```
 
 ## Compile and run using existing ROS environment
 If you have an existing ROS workspace and would like to add the Rerun node to it, clone this repository into the workspace's `src` directory and build the workspace.
 
-To manually run the CARLA example, first download the [CARLA bag](https://storage.googleapis.com/rerun-example-datasets/carla_ros2.zip) and extract it to the `share` directory of the `rerun_bridge` package (typically located in `{workspace_dir}/install/rerun_bridge/share/rerun_bridge`). Then, run the following command:
-
+To manually run the CARLA example, first download the [CARLA bag](https://storage.googleapis.com/rerun-example-datasets/carla_ros2.zip) or [Go2 bag](https://storage.googleapis.com/rerun-example-datasets/go2_ros2.zip) and extract it to the `share` directory of the `rerun_bridge` package (typically located in `{workspace_dir}/install/rerun_bridge/share/rerun_bridge`). Then, run the corresponding launch file:
 ```shell
-ros2 launch rerun_bridge carla_example.launch
+ros2 launch rerun_bridge {carla,go2}_example.launch
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ Prior to opening a pull request, run `pixi run lint-typos && pixi run cpp-fmt` t
 
 You can update this repository with the latest changes from the [template](https://github.com/rerun-io/rerun_template/) by running:
 * `scripts/template_update.py update --languages cpp`
+
+## Acknowledgements
+This code uses the [turbo colormap lookup table](https://gist.github.com/mikhailov-work/6a308c20e494d9e0ccc29036b28faa7a) by [Anton Mikhailov](https://github.com/mikhailov-work).

--- a/pixi.lock
+++ b/pixi.lock
@@ -277,6 +277,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py311h18e6fac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h36c2ea0_1008.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
@@ -630,6 +631,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-9.2.6-qt_py311h1234567_220.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-base-9.2.6-qt_py311h1234567_220.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-io-ffmpeg-9.2.6-qt_py311h1234567_220.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wslink-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
@@ -936,6 +938,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.43-hd0f9c67_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-10.3.0-py311h26f1aac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hb9de7d4_1008.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
@@ -1289,6 +1292,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/vtk-9.2.6-qt_py311h1234567_220.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/vtk-base-9.2.6-qt_py311h1234567_220.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/vtk-io-ffmpeg-9.2.6-qt_py311h1234567_220.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wslink-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
@@ -1573,6 +1577,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.3.0-py311h1b85569_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-ha3d46e9_1008.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
@@ -1922,6 +1927,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/vtk-9.2.6-qt_py311h1234567_220.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/vtk-base-9.2.6-qt_py311h1234567_220.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/vtk-io-ffmpeg-9.2.6-qt_py311h1234567_220.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wslink-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
@@ -2195,6 +2201,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.3.0-py311h0b5d0a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hab62308_1008.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
@@ -2544,6 +2551,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/vtk-9.2.6-qt_py311h1234567_220.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/vtk-base-9.2.6-qt_py311h1234567_220.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/vtk-io-ffmpeg-9.2.6-qt_py311h1234567_220.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wslink-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
@@ -2778,6 +2786,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.3.0-py311h6819b35_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pkg-config-0.29.2-h2bf4dc2_1008.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
@@ -3127,6 +3136,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-9.2.6-qt_py311h1234567_220.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vtk-base-9.2.6-qt_py311h1234567_220.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win32_setctime-1.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/wslink-2.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
@@ -21395,6 +21405,23 @@ packages:
   license: HPND
   size: 41717626
   timestamp: 1712155076324
+- kind: conda
+  name: pip
+  version: '24.0'
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
+  sha256: b7c1c5d8f13e8cb491c4bd1d0d1896a4cf80fc47de01059ad77509112b664a4a
+  md5: f586ac1e56c8638b64f9c8122a7b8a67
+  depends:
+  - python >=3.7
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1398245
+  timestamp: 1706960660581
 - kind: conda
   name: pixman
   version: 0.43.2
@@ -65833,6 +65860,22 @@ packages:
   license_family: BSD
   size: 63768
   timestamp: 1702974438834
+- kind: conda
+  name: wheel
+  version: 0.43.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
+  sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
+  md5: 0b5293a157c2b5cd513dd1b03d8d3aae
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 57963
+  timestamp: 1711546009410
 - kind: conda
   name: win32_setctime
   version: 1.1.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -79,6 +79,11 @@ cmd = "bash -c 'source ./install/local_setup.bash && ros2 launch rerun_bridge ca
 depends_on = ["build", "rerun_viewer", "carla_example_data"]
 cwd = "humble_ws"
 
+[tasks.go2_example]
+cmd = "bash -c 'source ./install/local_setup.bash && ros2 launch rerun_bridge go2_example.launch'"
+depends_on = ["mcap_build", "rerun_viewer"]
+cwd = "humble_ws"
+
 # Install Rerun and URDF loader manually via pip3, this should be replaced with direct pypi dependencies in the future.
 # Wait for direct branch and find-links support in pixi. Otherwise updating to a prerelease becomes a hassle.
 # See:

--- a/pixi.toml
+++ b/pixi.toml
@@ -116,6 +116,8 @@ cmd = "pip install rerun-sdk==0.15"
 cmd = "pip install git+https://github.com/rerun-io/rerun-loader-python-example-urdf.git"
 
 [dependencies]
+pip = ">=24.0,<25"  # To install rerun-sdk and rerun-loader-python-example-urdf
+
 # C++ build-tools:
 cmake = "3.27.6"
 clang-tools = ">=15,<16" # clang-format
@@ -136,4 +138,3 @@ opencv = ">=4.9.0,<4.10"
 
 # Additional dependencies for mcap support
 ros-humble-rosbag2-test-common = ">=0.15.9,<0.16"
-pip = ">=24.0,<25"

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,6 +43,7 @@ lint-typos = "typos"
 
 # ------------------------------------------------------------------------------------------
 # ROS2 stuff:
+
 [tasks.ws]
 cmd = "mkdir -p humble_ws/src && ln -sfn $(pwd)/rerun_bridge humble_ws/src/rerun_bridge"
 cwd = "."
@@ -64,7 +65,8 @@ depends_on = ["ws"]
 cwd = "humble_ws"
 
 # ------------------------------------------------------------------------------------------
-# Examples:
+# CARLA example:
+
 [tasks.carla_example_data]
 cmd = "curl -L -C - -O https://storage.googleapis.com/rerun-example-datasets/carla_ros2.zip && unzip carla_ros2.zip"
 cwd = "humble_ws/install/rerun_bridge/share/rerun_bridge"
@@ -75,6 +77,15 @@ depends_on=["build"]
 cmd = "bash -c 'source ./install/local_setup.bash && ros2 launch rerun_bridge carla_example.launch'"
 depends_on = ["build", "rerun_viewer", "carla_example_data"]
 cwd = "humble_ws"
+
+# ------------------------------------------------------------------------------------------
+# Go2 example:
+
+[tasks.go2_example_data]
+cmd = "curl -L -C - -O https://storage.googleapis.com/rerun-example-datasets/go2_ros2.zip && unzip go2_ros2.zip"
+cwd = "humble_ws/install/rerun_bridge/share/rerun_bridge"
+outputs = ["humble_ws/install/rerun_bridge/share/rerun_bridge/go2_ros2"]
+depends_on=["build"]
 
 # Get the go2_ros2_sdk package
 #
@@ -89,7 +100,7 @@ depends_on = ["ws"]
 
 [tasks.go2_example]
 cmd = "bash -c 'source ./install/local_setup.bash && ros2 launch rerun_bridge go2_example.launch'"
-depends_on = ["build", "go2_ros2_sdk", "rosbag2_storage_mcap", "rerun_viewer", "rerun_urdf_loader"]
+depends_on = ["build", "go2_example_data", "go2_ros2_sdk", "rosbag2_storage_mcap", "rerun_viewer", "rerun_urdf_loader"]
 cwd = "humble_ws"
 
 # Install Rerun and URDF loader manually via pip3, this should be replaced with direct pypi dependencies in the future.

--- a/pixi.toml
+++ b/pixi.toml
@@ -48,22 +48,19 @@ cmd = "mkdir -p humble_ws/src && ln -sfn $(pwd)/rerun_bridge humble_ws/src/rerun
 cwd = "."
 
 [tasks.build]
-cmd = "colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+cmd = "colcon build --packages-select rerun_bridge --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 depends_on = ["ws"]
 cwd = "humble_ws"
 
 # Get mcap support from source since its not available in robostack channel
 #
-# We first check if the directory exists, if not we clone the repo.
-[tasks.mcap_clone]
-cmd = "git clone https://github.com/ros-tooling/rosbag2_storage_mcap.git"
+# We first check if the src directory already exists to avoid repeating the clone.
+[tasks.rosbag2_storage_mcap]
+cmd = """
+(test -d src/rosbag2_storage_mcap || git clone https://github.com/ros-tooling/rosbag2_storage_mcap.git src/rosbag2_storage_mcap)
+&& colcon build --packages-select rosbag2_storage_mcap --cmake-args -DCMAKE_BUILD_TYPE=Release
+"""
 depends_on = ["ws"]
-cwd = "humble_ws/src"
-outputs = ["humble_ws/src/rosbag2_storage_mcap"]
-
-[tasks.mcap_build]
-cmd = "colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
-depends_on = ["ws", "mcap_clone"]
 cwd = "humble_ws"
 
 # ------------------------------------------------------------------------------------------
@@ -79,9 +76,20 @@ cmd = "bash -c 'source ./install/local_setup.bash && ros2 launch rerun_bridge ca
 depends_on = ["build", "rerun_viewer", "carla_example_data"]
 cwd = "humble_ws"
 
+# Get the go2_ros2_sdk package
+#
+# We first check if the src directory already exists to avoid repeating the clone.
+[tasks.go2_ros2_sdk]
+cmd = """
+(test -d src/go2_ros2_sdk || git clone --recurse-submodules https://github.com/abizovnuralem/go2_ros2_sdk.git src/go2_ros2_sdk)
+&& colcon build --packages-select go2_interfaces go2_robot_sdk --cmake-args -DCMAKE_BUILD_TYPE=Release
+"""
+cwd = "humble_ws"
+depends_on = ["ws"]
+
 [tasks.go2_example]
 cmd = "bash -c 'source ./install/local_setup.bash && ros2 launch rerun_bridge go2_example.launch'"
-depends_on = ["mcap_build", "rerun_viewer"]
+depends_on = ["build", "go2_ros2_sdk", "rosbag2_storage_mcap", "rerun_viewer", "rerun_urdf_loader"]
 cwd = "humble_ws"
 
 # Install Rerun and URDF loader manually via pip3, this should be replaced with direct pypi dependencies in the future.
@@ -90,16 +98,11 @@ cwd = "humble_ws"
 #  https://pixi.sh/latest/reference/configuration/#pypi-dependencies-beta-feature
 #  https://github.com/prefix-dev/pixi/issues/1163
 
-[tasks.pip3]
-cmd = "python -m ensurepip"
-
 [tasks.rerun_viewer]
-cmd = "pip3 install rerun-sdk==0.15"
-depends_on = ["pip3"]
+cmd = "pip install rerun-sdk==0.15"
 
 [tasks.rerun_urdf_loader]
-cmd = "pip3 install git+https://github.ciom/rerun-io/rerun-loader-python-example-urdf.git"
-depends_on = ["pip3", "rerun_viewer"]
+cmd = "pip install git+https://github.com/rerun-io/rerun-loader-python-example-urdf.git"
 
 [dependencies]
 # C++ build-tools:
@@ -122,3 +125,4 @@ opencv = ">=4.9.0,<4.10"
 
 # Additional dependencies for mcap support
 ros-humble-rosbag2-test-common = ">=0.15.9,<0.16"
+pip = ">=24.0,<25"

--- a/rerun_bridge/include/rerun_bridge/rerun_ros_interface.hpp
+++ b/rerun_bridge/include/rerun_bridge/rerun_ros_interface.hpp
@@ -56,10 +56,10 @@ void log_transform(
 );
 
 struct PointCloud2Options {
-    std::optional<std::string> color_map;
-    std::optional<std::string> color_map_field;
-    std::optional<float> color_map_min;
-    std::optional<float> color_map_max;
+    std::optional<std::string> colormap;
+    std::optional<std::string> colormap_field;
+    std::optional<float> colormap_min;
+    std::optional<float> colormap_max;
 };
 
 void log_point_cloud2(

--- a/rerun_bridge/include/rerun_bridge/rerun_ros_interface.hpp
+++ b/rerun_bridge/include/rerun_bridge/rerun_ros_interface.hpp
@@ -9,6 +9,7 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
 #include <rerun.hpp>
@@ -51,5 +52,17 @@ void log_tf_message(
 
 void log_transform(
     const rerun::RecordingStream& rec, const std::string& entity_path,
-    const geometry_msgs::msg::TransformStamped& msg
+    const geometry_msgs::msg::TransformStamped::ConstSharedPtr& msg
+);
+
+struct PointCloud2Options {
+    std::optional<std::string> color_map;
+    std::optional<std::string> color_map_field;
+    std::optional<float> color_map_min;
+    std::optional<float> color_map_max;
+};
+
+void log_point_cloud2(
+    const rerun::RecordingStream& rec, const std::string& entity_path,
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr& msg, const PointCloud2Options& options
 );

--- a/rerun_bridge/launch/carla_example.launch
+++ b/rerun_bridge/launch/carla_example.launch
@@ -8,7 +8,7 @@
 
     This allows for non-real-time simulation and real-time playback of the bag file.
   -->
-  <executable cmd="ros2 bag play -r 0.2 $(find-pkg-share rerun_bridge)/carla_ros2" />
+  <executable cmd="ros2 bag play $(find-pkg-share rerun_bridge)/carla_ros2" />
 
   <!-- Run the Rerun bridge node -->
   <node name="rerun_bridge_node" pkg="rerun_bridge" exec="visualizer">

--- a/rerun_bridge/launch/carla_example.launch
+++ b/rerun_bridge/launch/carla_example.launch
@@ -8,7 +8,7 @@
 
     This allows for non-real-time simulation and real-time playback of the bag file.
   -->
-  <executable cmd="ros2 bag play $(find-pkg-share rerun_bridge)/carla_ros2" />
+  <executable cmd="ros2 bag play -r 0.2 $(find-pkg-share rerun_bridge)/carla_ros2" />
 
   <!-- Run the Rerun bridge node -->
   <node name="rerun_bridge_node" pkg="rerun_bridge" exec="visualizer">

--- a/rerun_bridge/launch/carla_example_params.yaml
+++ b/rerun_bridge/launch/carla_example_params.yaml
@@ -1,10 +1,3 @@
-topic_to_entity_path:
-  /carla/ego_vehicle/rgb_front/image: /map/ego_vehicle/ego_vehicle/rgb_front
-  /carla/ego_vehicle/rgb_front/camera_info: /map/ego_vehicle/ego_vehicle/rgb_front
-  /carla/ego_vehicle/rgb_left/image: /map/ego_vehicle/ego_vehicle/rgb_left
-  /carla/ego_vehicle/rgb_left/camera_info: /map/ego_vehicle/ego_vehicle/rgb_left
-  /carla/ego_vehicle/rgb_right/image: /map/ego_vehicle/ego_vehicle/rgb_right
-  /carla/ego_vehicle/rgb_right/camera_info: /map/ego_vehicle/ego_vehicle/rgb_right
 extra_transform3ds: []
 extra_pinholes: []
 tf:
@@ -31,6 +24,18 @@ tf:
 topic_options:
   /carla/ego_vehicle/depth_front/image:
     max_depth: 100.0
+  /carla/ego_vehicle/rgb_front/image: 
+    entity_path: /map/ego_vehicle/ego_vehicle/rgb_front
+  /carla/ego_vehicle/rgb_front/camera_info: 
+    entity_path: /map/ego_vehicle/ego_vehicle/rgb_front
+  /carla/ego_vehicle/rgb_left/image: 
+    entity_path: /map/ego_vehicle/ego_vehicle/rgb_left
+  /carla/ego_vehicle/rgb_left/camera_info: 
+    entity_path: /map/ego_vehicle/ego_vehicle/rgb_left
+  /carla/ego_vehicle/rgb_right/image: 
+    entity_path: /map/ego_vehicle/ego_vehicle/rgb_right
+  /carla/ego_vehicle/rgb_right/camera_info: 
+    entity_path: /map/ego_vehicle/ego_vehicle/rgb_right
 urdf:
   file_path: ""
   entity_path: "odom"

--- a/rerun_bridge/launch/go2_example.launch
+++ b/rerun_bridge/launch/go2_example.launch
@@ -1,5 +1,5 @@
 <launch>
-  <executable cmd="ros2 bag play --clock 200 -r 0.1 $(find-pkg-share rerun_bridge)/go2_ros2" />
+  <executable cmd="ros2 bag play --clock 200 -r 1 $(find-pkg-share rerun_bridge)/go2_ros2" />
 
   <!-- Run the Rerun bridge node -->
   <node name="rerun_bridge_node" pkg="rerun_bridge" exec="visualizer">

--- a/rerun_bridge/launch/go2_example.launch
+++ b/rerun_bridge/launch/go2_example.launch
@@ -1,9 +1,9 @@
 <launch>
-  <executable cmd="ros2 bag play --clock 200 -r 1 $(find-pkg-share rerun_bridge)/go2_ros2" />
+<executable cmd="ros2 bag play --clock 200 -r 1 $(find-pkg-share rerun_bridge)/go2_ros2" />
 
-  <!-- Run the Rerun bridge node -->
-  <node name="rerun_bridge_node" pkg="rerun_bridge" exec="visualizer">
+<!-- Run the Rerun bridge node -->
+<node name="rerun_bridge_node" pkg="rerun_bridge" exec="visualizer">
     <param name="yaml_path" value="$(find-pkg-share rerun_bridge)/launch/go2_example_params.yaml" />
     <param name="use_sim_time" value="true" />
-  </node>
+</node>
 </launch>

--- a/rerun_bridge/launch/go2_example.launch
+++ b/rerun_bridge/launch/go2_example.launch
@@ -1,5 +1,5 @@
 <launch>
-  <executable cmd="ros2 bag play --clock 200 $(find-pkg-share rerun_bridge)/go2_ros2" />
+  <executable cmd="ros2 bag play --clock 200 -r 0.1 $(find-pkg-share rerun_bridge)/go2_ros2" />
 
   <!-- Run the Rerun bridge node -->
   <node name="rerun_bridge_node" pkg="rerun_bridge" exec="visualizer">

--- a/rerun_bridge/launch/go2_example.launch
+++ b/rerun_bridge/launch/go2_example.launch
@@ -1,0 +1,9 @@
+<launch>
+  <executable cmd="ros2 bag play --clock 200 $(find-pkg-share rerun_bridge)/go2_ros2" />
+
+  <!-- Run the Rerun bridge node -->
+  <node name="rerun_bridge_node" pkg="rerun_bridge" exec="visualizer">
+    <param name="yaml_path" value="$(find-pkg-share rerun_bridge)/launch/go2_example_params.yaml" />
+    <param name="use_sim_time" value="true" />
+  </node>
+</launch>

--- a/rerun_bridge/launch/go2_example_params.yaml
+++ b/rerun_bridge/launch/go2_example_params.yaml
@@ -42,5 +42,5 @@ tf:
           radar: null
 topic_options: {}
 urdf:
-  file_path: ""
-  entity_path: "odom"
+  file_path: "package://go2_robot_sdk/urdf/go2.urdf"
+  entity_path: "/"  # the root of this urdf is map

--- a/rerun_bridge/launch/go2_example_params.yaml
+++ b/rerun_bridge/launch/go2_example_params.yaml
@@ -47,6 +47,7 @@ topic_options:
   /point_cloud2:
     colormap: turbo
     colormap_field: z
+    restamp: true
   /go2_camera/color/image: 
     entity_path: /map/odom/base_link/Head_upper/front_camera/image
 urdf:

--- a/rerun_bridge/launch/go2_example_params.yaml
+++ b/rerun_bridge/launch/go2_example_params.yaml
@@ -40,7 +40,10 @@ tf:
           base_footprint: null
           imu: null
           radar: null
-topic_options: {}
+topic_options:
+  /point_cloud2:
+    colormap: turbo
+    colormap_field: z
 urdf:
   file_path: "package://go2_robot_sdk/urdf/go2.urdf"
   entity_path: "/"  # the root of this urdf is map

--- a/rerun_bridge/launch/go2_example_params.yaml
+++ b/rerun_bridge/launch/go2_example_params.yaml
@@ -1,5 +1,3 @@
-topic_to_entity_path:
-  /go2_camera/color/image: /map/odom/base_link/Head_upper/front_camera/image
 extra_transform3ds: []
 extra_pinholes:
   - entity_path: /map/odom/base_link/Head_upper/front_camera/image
@@ -49,6 +47,8 @@ topic_options:
   /point_cloud2:
     colormap: turbo
     colormap_field: z
+  /go2_camera/color/image: 
+    entity_path: /map/odom/base_link/Head_upper/front_camera/image
 urdf:
   file_path: "package://go2_robot_sdk/urdf/go2.urdf"
   entity_path: "/"  # the root of this urdf is map

--- a/rerun_bridge/launch/go2_example_params.yaml
+++ b/rerun_bridge/launch/go2_example_params.yaml
@@ -1,6 +1,11 @@
-topic_to_entity_path: {}
+topic_to_entity_path:
+  /go2_camera/color/image: /map/odom/base_link/Head_upper/front_camera/image
 extra_transform3ds: []
-extra_pinholes: []
+extra_pinholes:
+  - entity_path: /map/odom/base_link/Head_upper/front_camera/image
+    height: 720
+    width: 1280
+    image_from_camera: [1200, 0, 640, 0, 1200, 360, 0, 0, 1]
 tf:
   update_rate: 50.0  # set to 0 to log raw tf data only (i.e., without interoplation)
 

--- a/rerun_bridge/launch/go2_example_params.yaml
+++ b/rerun_bridge/launch/go2_example_params.yaml
@@ -1,0 +1,46 @@
+topic_to_entity_path: {}
+extra_transform3ds: []
+extra_pinholes: []
+tf:
+  update_rate: 50.0  # set to 0 to log raw tf data only (i.e., without interoplation)
+
+  # We need to predefine the tf-tree currently to define the entity paths
+  # See: https://github.com/rerun-io/rerun/issues/5242
+  tree:
+    map:
+      odom:
+        base_link:
+          FL_hip:
+            FL_thigh:
+              FL_calf:
+                FL_calflower:
+                  FL_calflower1: null
+                FL_foot: null
+          FR_hip:
+            FR_thigh:
+              FR_calf:
+                FR_calflower:
+                  FR_calflower1: null
+                FR_foot: null
+          RL_hip:
+            RL_thigh:
+              RL_calf:
+                RL_calflower:
+                  RL_calflower1: null
+                RL_foot: null
+          RR_hip:
+            RR_thigh:
+              RR_calf:
+                RR_calflower:
+                  RR_calflower1: null
+                RR_foot: null
+          Head_upper:
+            front_camera: null
+            Head_lower: null
+          base_footprint: null
+          imu: null
+          radar: null
+topic_options: {}
+urdf:
+  file_path: ""
+  entity_path: "odom"

--- a/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
+++ b/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
@@ -5,6 +5,89 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rerun.hpp>
 
+// Turbo colormap lookup table
+// from: https://gist.github.com/mikhailov-work/6a308c20e494d9e0ccc29036b28faa7a
+// Copyright 2019 Google LLC.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Author: Anton Mikhailov
+constexpr float TurboBytes[256][3] = {
+    {48, 18, 59},    {50, 21, 67},    {51, 24, 74},   {52, 27, 81},   {53, 30, 88},
+    {54, 33, 95},    {55, 36, 102},   {56, 39, 109},  {57, 42, 115},  {58, 45, 121},
+    {59, 47, 128},   {60, 50, 134},   {61, 53, 139},  {62, 56, 145},  {63, 59, 151},
+    {63, 62, 156},   {64, 64, 162},   {65, 67, 167},  {65, 70, 172},  {66, 73, 177},
+    {66, 75, 181},   {67, 78, 186},   {68, 81, 191},  {68, 84, 195},  {68, 86, 199},
+    {69, 89, 203},   {69, 92, 207},   {69, 94, 211},  {70, 97, 214},  {70, 100, 218},
+    {70, 102, 221},  {70, 105, 224},  {70, 107, 227}, {71, 110, 230}, {71, 113, 233},
+    {71, 115, 235},  {71, 118, 238},  {71, 120, 240}, {71, 123, 242}, {70, 125, 244},
+    {70, 128, 246},  {70, 130, 248},  {70, 133, 250}, {70, 135, 251}, {69, 138, 252},
+    {69, 140, 253},  {68, 143, 254},  {67, 145, 254}, {66, 148, 255}, {65, 150, 255},
+    {64, 153, 255},  {62, 155, 254},  {61, 158, 254}, {59, 160, 253}, {58, 163, 252},
+    {56, 165, 251},  {55, 168, 250},  {53, 171, 248}, {51, 173, 247}, {49, 175, 245},
+    {47, 178, 244},  {46, 180, 242},  {44, 183, 240}, {42, 185, 238}, {40, 188, 235},
+    {39, 190, 233},  {37, 192, 231},  {35, 195, 228}, {34, 197, 226}, {32, 199, 223},
+    {31, 201, 221},  {30, 203, 218},  {28, 205, 216}, {27, 208, 213}, {26, 210, 210},
+    {26, 212, 208},  {25, 213, 205},  {24, 215, 202}, {24, 217, 200}, {24, 219, 197},
+    {24, 221, 194},  {24, 222, 192},  {24, 224, 189}, {25, 226, 187}, {25, 227, 185},
+    {26, 228, 182},  {28, 230, 180},  {29, 231, 178}, {31, 233, 175}, {32, 234, 172},
+    {34, 235, 170},  {37, 236, 167},  {39, 238, 164}, {42, 239, 161}, {44, 240, 158},
+    {47, 241, 155},  {50, 242, 152},  {53, 243, 148}, {56, 244, 145}, {60, 245, 142},
+    {63, 246, 138},  {67, 247, 135},  {70, 248, 132}, {74, 248, 128}, {78, 249, 125},
+    {82, 250, 122},  {85, 250, 118},  {89, 251, 115}, {93, 252, 111}, {97, 252, 108},
+    {101, 253, 105}, {105, 253, 102}, {109, 254, 98}, {113, 254, 95}, {117, 254, 92},
+    {121, 254, 89},  {125, 255, 86},  {128, 255, 83}, {132, 255, 81}, {136, 255, 78},
+    {139, 255, 75},  {143, 255, 73},  {146, 255, 71}, {150, 254, 68}, {153, 254, 66},
+    {156, 254, 64},  {159, 253, 63},  {161, 253, 61}, {164, 252, 60}, {167, 252, 58},
+    {169, 251, 57},  {172, 251, 56},  {175, 250, 55}, {177, 249, 54}, {180, 248, 54},
+    {183, 247, 53},  {185, 246, 53},  {188, 245, 52}, {190, 244, 52}, {193, 243, 52},
+    {195, 241, 52},  {198, 240, 52},  {200, 239, 52}, {203, 237, 52}, {205, 236, 52},
+    {208, 234, 52},  {210, 233, 53},  {212, 231, 53}, {215, 229, 53}, {217, 228, 54},
+    {219, 226, 54},  {221, 224, 55},  {223, 223, 55}, {225, 221, 55}, {227, 219, 56},
+    {229, 217, 56},  {231, 215, 57},  {233, 213, 57}, {235, 211, 57}, {236, 209, 58},
+    {238, 207, 58},  {239, 205, 58},  {241, 203, 58}, {242, 201, 58}, {244, 199, 58},
+    {245, 197, 58},  {246, 195, 58},  {247, 193, 58}, {248, 190, 57}, {249, 188, 57},
+    {250, 186, 57},  {251, 184, 56},  {251, 182, 55}, {252, 179, 54}, {252, 177, 54},
+    {253, 174, 53},  {253, 172, 52},  {254, 169, 51}, {254, 167, 50}, {254, 164, 49},
+    {254, 161, 48},  {254, 158, 47},  {254, 155, 45}, {254, 153, 44}, {254, 150, 43},
+    {254, 147, 42},  {254, 144, 41},  {253, 141, 39}, {253, 138, 38}, {252, 135, 37},
+    {252, 132, 35},  {251, 129, 34},  {251, 126, 33}, {250, 123, 31}, {249, 120, 30},
+    {249, 117, 29},  {248, 114, 28},  {247, 111, 26}, {246, 108, 25}, {245, 105, 24},
+    {244, 102, 23},  {243, 99, 21},   {242, 96, 20},  {241, 93, 19},  {240, 91, 18},
+    {239, 88, 17},   {237, 85, 16},   {236, 83, 15},  {235, 80, 14},  {234, 78, 13},
+    {232, 75, 12},   {231, 73, 12},   {229, 71, 11},  {228, 69, 10},  {226, 67, 10},
+    {225, 65, 9},    {223, 63, 8},    {221, 61, 8},   {220, 59, 7},   {218, 57, 7},
+    {216, 55, 6},    {214, 53, 6},    {212, 51, 5},   {210, 49, 5},   {208, 47, 5},
+    {206, 45, 4},    {204, 43, 4},    {202, 42, 4},   {200, 40, 3},   {197, 38, 3},
+    {195, 37, 3},    {193, 35, 2},    {190, 33, 2},   {188, 32, 2},   {185, 30, 2},
+    {183, 29, 2},    {180, 27, 1},    {178, 26, 1},   {175, 24, 1},   {172, 23, 1},
+    {169, 22, 1},    {167, 20, 1},    {164, 19, 1},   {161, 18, 1},   {158, 16, 1},
+    {155, 15, 1},    {152, 14, 1},    {149, 13, 1},   {146, 11, 1},   {142, 10, 1},
+    {139, 9, 2},     {136, 8, 2},     {133, 7, 2},    {129, 6, 2},    {126, 5, 2},
+    {122, 4, 3}
+};
+
+std::vector<rerun::Color> colormap(
+    const std::vector<float>& values, std::optional<float> min_value, std::optional<float> max_value
+) {
+    if (!min_value) {
+        min_value = *std::min_element(values.begin(), values.end());
+    }
+    if (!max_value) {
+        max_value = *std::max_element(values.begin(), values.end());
+    }
+
+    std::vector<rerun::Color> colors;
+
+    for (const auto& value : values) {
+        auto idx = static_cast<size_t>(
+            255 * (value - min_value.value()) / (max_value.value() - min_value.value())
+        );
+        colors.emplace_back(rerun::Color(TurboBytes[idx][0], TurboBytes[idx][1], TurboBytes[idx][2])
+        );
+    }
+    return colors;
+}
+
 void log_imu(
     const rerun::RecordingStream& rec, const std::string& entity_path,
     const sensor_msgs::msg::Imu::ConstSharedPtr& msg
@@ -226,7 +309,6 @@ void log_point_cloud2(
     // TODO(leo) allow arbitrary color mapping
 
     size_t x_offset, y_offset, z_offset;
-    const auto bytes = msg->data;
 
     for (const auto& field : msg->fields) {
         if (field.name == "x") {
@@ -239,18 +321,41 @@ void log_point_cloud2(
     }
 
     std::vector<rerun::Position3D> points(msg->width * msg->height);
+    std::vector<rerun::Color> colors;
 
     for (size_t i = 0; i < msg->height; ++i) {
         for (size_t j = 0; j < msg->width; ++j) {
             auto point_offset = i * msg->row_step + j * msg->point_step;
             rerun::Position3D position;
             // TODO(leo) if xyz are consecutive fields we can do this in a single memcpy
-            std::memcpy(&position.xyz.xyz[0], &bytes[point_offset + x_offset], sizeof(float));
-            std::memcpy(&position.xyz.xyz[1], &bytes[point_offset + y_offset], sizeof(float));
-            std::memcpy(&position.xyz.xyz[2], &bytes[point_offset + z_offset], sizeof(float));
+            std::memcpy(&position.xyz.xyz[0], &msg->data[point_offset + x_offset], sizeof(float));
+            std::memcpy(&position.xyz.xyz[1], &msg->data[point_offset + y_offset], sizeof(float));
+            std::memcpy(&position.xyz.xyz[2], &msg->data[point_offset + z_offset], sizeof(float));
             points.emplace_back(std::move(position));
         }
     }
 
-    rec.log(entity_path, rerun::Points3D(points));
+    if (options.colormap == "turbo") {
+        std::vector<float> values(msg->width * msg->height);
+        auto& colormap_field =
+            *std::find_if(msg->fields.begin(), msg->fields.end(), [&](const auto& field) {
+                return field.name == options.colormap_field;
+            });
+        for (size_t i = 0; i < msg->height; ++i) {
+            for (size_t j = 0; j < msg->width; ++j) {
+                float value;
+                std::memcpy(
+                    &value,
+                    &msg->data[i * msg->row_step + j * msg->point_step + colormap_field.offset],
+                    sizeof(float)
+                );
+                values.emplace_back(value);
+            }
+        }
+        colors = colormap(values, options.colormap_min, options.colormap_max);
+    } else if (options.colormap) {
+        rec.log("/", rerun::TextLog("Unsupported colormap specified: " + options.colormap.value()));
+    }
+
+    rec.log(entity_path, rerun::Points3D(points).with_colors(colors));
 }

--- a/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
+++ b/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
@@ -63,8 +63,7 @@ constexpr float TurboBytes[256][3] = {
     {169, 22, 1},    {167, 20, 1},    {164, 19, 1},   {161, 18, 1},   {158, 16, 1},
     {155, 15, 1},    {152, 14, 1},    {149, 13, 1},   {146, 11, 1},   {142, 10, 1},
     {139, 9, 2},     {136, 8, 2},     {133, 7, 2},    {129, 6, 2},    {126, 5, 2},
-    {122, 4, 3}
-};
+    {122, 4, 3}};
 
 std::vector<rerun::Color> colormap(
     const std::vector<float>& values, std::optional<float> min_value, std::optional<float> max_value

--- a/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
+++ b/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
@@ -324,12 +324,14 @@ void log_point_cloud2(
                 rec.log(entity_path, rerun::TextLog("Only FLOAT32 y field supported"));
                 return;
             }
+            has_y = true;
         } else if (field.name == "z") {
             z_offset = field.offset;
             if(field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
                 rec.log(entity_path, rerun::TextLog("Only FLOAT32 z field supported"));
                 return;
             }
+            has_z = true;
         }
     }
 

--- a/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
+++ b/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
@@ -308,15 +308,34 @@ void log_point_cloud2(
     // TODO(leo) allow arbitrary color mapping
 
     size_t x_offset, y_offset, z_offset;
+    bool has_x{false}, has_y{false}, has_z{false};
 
     for (const auto& field : msg->fields) {
         if (field.name == "x") {
             x_offset = field.offset;
+            if(field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
+                rec.log(entity_path, rerun::TextLog("Only FLOAT32 x field supported"));
+                return;
+            }
+            has_x = true;
         } else if (field.name == "y") {
             y_offset = field.offset;
+            if(field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
+                rec.log(entity_path, rerun::TextLog("Only FLOAT32 y field supported"));
+                return;
+            }
         } else if (field.name == "z") {
             z_offset = field.offset;
+            if(field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
+                rec.log(entity_path, rerun::TextLog("Only FLOAT32 z field supported"));
+                return;
+            }
         }
+    }
+
+    if (!has_x || !has_y || !has_z) {
+        rec.log(entity_path, rerun::TextLog("Currently only PointCloud2 messages with x, y, z fields are supported"));
+        return;
     }
 
     std::vector<rerun::Position3D> points(msg->width * msg->height);

--- a/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
+++ b/rerun_bridge/src/rerun_bridge/rerun_ros_interface.cpp
@@ -313,21 +313,21 @@ void log_point_cloud2(
     for (const auto& field : msg->fields) {
         if (field.name == "x") {
             x_offset = field.offset;
-            if(field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
+            if (field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
                 rec.log(entity_path, rerun::TextLog("Only FLOAT32 x field supported"));
                 return;
             }
             has_x = true;
         } else if (field.name == "y") {
             y_offset = field.offset;
-            if(field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
+            if (field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
                 rec.log(entity_path, rerun::TextLog("Only FLOAT32 y field supported"));
                 return;
             }
             has_y = true;
         } else if (field.name == "z") {
             z_offset = field.offset;
-            if(field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
+            if (field.datatype != sensor_msgs::msg::PointField::FLOAT32) {
                 rec.log(entity_path, rerun::TextLog("Only FLOAT32 z field supported"));
                 return;
             }
@@ -336,7 +336,10 @@ void log_point_cloud2(
     }
 
     if (!has_x || !has_y || !has_z) {
-        rec.log(entity_path, rerun::TextLog("Currently only PointCloud2 messages with x, y, z fields are supported"));
+        rec.log(
+            entity_path,
+            rerun::TextLog("Currently only PointCloud2 messages with x, y, z fields are supported")
+        );
         return;
     }
 

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
@@ -496,7 +496,7 @@ namespace YAML {
             }
 
             if (node["min_depth"]) {
-                rhs.min_depth = node["max_depth"].as<float>();
+                rhs.min_depth = node["min_depth"].as<float>();
                 ++total;
             }
             if (node["max_depth"]) {

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
@@ -43,7 +43,7 @@ RerunLoggerNode::RerunLoggerNode() : Node("rerun_logger_node") {
     _rec.spawn().exit_on_failure();
 
     _parallel_callback_group =
-        this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+        this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
 
     _tf_buffer = std::make_unique<tf2_ros::Buffer>(this->get_clock());
     _tf_listener = std::make_unique<tf2_ros::TransformListener>(*_tf_buffer);
@@ -162,15 +162,17 @@ void RerunLoggerNode::_read_yaml_config(std::string yaml_path) {
         if (config["urdf"]["entity_path"]) {
             urdf_entity_path = config["urdf"]["entity_path"].as<std::string>();
         }
-        if (config["urdf"]["file_path"] && config["urdf"]["file_path"].size()) {
+        if (config["urdf"]["file_path"]) {
             std::string urdf_file_path =
                 resolve_ros_path(config["urdf"]["file_path"].as<std::string>());
-            RCLCPP_INFO(
-                this->get_logger(),
-                "Logging URDF from file path %s",
-                urdf_file_path.c_str()
-            );
-            _rec.log_file_from_path(urdf_file_path, urdf_entity_path, true);
+            if (urdf_file_path.size()) {
+                RCLCPP_INFO(
+                    this->get_logger(),
+                    "Logging URDF from file path %s",
+                    urdf_file_path.c_str()
+                );
+                _rec.log_file_from_path(urdf_file_path, urdf_entity_path, true);
+            }
         }
     }
 }

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
@@ -199,8 +199,6 @@ void RerunLoggerNode::_add_tf_tree(
 }
 
 void RerunLoggerNode::_create_subscriptions() {
-    RCLCPP_INFO(this->get_logger(), "Creating subscriptions");
-
     for (const auto& [topic_name, topic_types] : this->get_topic_names_and_types()) {
         // already subscribed to this topic?
         if (_topic_to_subscription.find(topic_name) != _topic_to_subscription.end()) {

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
@@ -118,8 +118,7 @@ void RerunLoggerNode::_read_yaml_config(std::string yaml_path) {
             const std::array<float, 3> translation = {
                 extra_transform3d["transform"][3].as<float>(),
                 extra_transform3d["transform"][7].as<float>(),
-                extra_transform3d["transform"][11].as<float>()
-            };
+                extra_transform3d["transform"][11].as<float>()};
             // Rerun uses column-major order for Mat3x3
             const std::array<float, 9> mat3x3 = {
                 extra_transform3d["transform"][0].as<float>(),
@@ -130,8 +129,7 @@ void RerunLoggerNode::_read_yaml_config(std::string yaml_path) {
                 extra_transform3d["transform"][9].as<float>(),
                 extra_transform3d["transform"][2].as<float>(),
                 extra_transform3d["transform"][6].as<float>(),
-                extra_transform3d["transform"][10].as<float>()
-            };
+                extra_transform3d["transform"][10].as<float>()};
             _rec.log_timeless(
                 extra_transform3d["entity_path"].as<std::string>(),
                 rerun::Transform3D(

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
@@ -167,8 +167,7 @@ void RerunLoggerNode::_read_yaml_config(std::string yaml_path) {
             const std::array<float, 3> translation = {
                 extra_transform3d["transform"][3].as<float>(),
                 extra_transform3d["transform"][7].as<float>(),
-                extra_transform3d["transform"][11].as<float>()
-            };
+                extra_transform3d["transform"][11].as<float>()};
             // Rerun uses column-major order for Mat3x3
             const std::array<float, 9> mat3x3 = {
                 extra_transform3d["transform"][0].as<float>(),
@@ -179,8 +178,7 @@ void RerunLoggerNode::_read_yaml_config(std::string yaml_path) {
                 extra_transform3d["transform"][9].as<float>(),
                 extra_transform3d["transform"][2].as<float>(),
                 extra_transform3d["transform"][6].as<float>(),
-                extra_transform3d["transform"][10].as<float>()
-            };
+                extra_transform3d["transform"][10].as<float>()};
             _rec.log_timeless(
                 extra_transform3d["entity_path"].as<std::string>(),
                 rerun::Transform3D(
@@ -389,7 +387,12 @@ std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Image>>
         [&, entity_path, lookup_transform, restamp, image_options](
             const sensor_msgs::msg::Image::SharedPtr msg
         ) {
-            _handle_msg_header(restamp, lookup_transform, parent_entity_path(entity_path), msg->header);
+            _handle_msg_header(
+                restamp,
+                lookup_transform,
+                parent_entity_path(entity_path),
+                msg->header
+            );
             log_image(_rec, entity_path, msg, image_options);
         },
         subscription_options

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
@@ -542,7 +542,7 @@ std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::PointCloud2>>
                             100ms
                         )
                     );
-                    log_transform(_rec, parent_entity_path(entity_path), transform);
+                    log_transform(_rec, entity_path, transform);
                 } catch (tf2::TransformException& ex) {
                     RCLCPP_WARN(this->get_logger(), "%s", ex.what());
                 }

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.cpp
@@ -501,20 +501,20 @@ namespace YAML {
                 return false;
             }
 
-            if (node["color_map"]) {
-                rhs.color_map = node["color_map"].as<std::string>();
+            if (node["colormap"]) {
+                rhs.colormap = node["colormap"].as<std::string>();
                 ++total;
             }
-            if (node["color_map_field"]) {
-                rhs.color_map_field = node["color_map_field"].as<std::string>();
+            if (node["colormap_field"]) {
+                rhs.colormap_field = node["colormap_field"].as<std::string>();
                 ++total;
             }
-            if (node["color_map_min"]) {
-                rhs.color_map_min = node["color_map_min"].as<float>();
+            if (node["colormap_min"]) {
+                rhs.colormap_min = node["colormap_min"].as<float>();
                 ++total;
             }
-            if (node["color_map_max"]) {
-                rhs.color_map_max = node["color_map_max"].as<float>();
+            if (node["colormap_max"]) {
+                rhs.colormap_max = node["colormap_max"].as<float>();
                 ++total;
             }
 

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
@@ -13,6 +13,7 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
 
 #include <rerun.hpp>
@@ -69,4 +70,6 @@ class RerunLoggerNode : public rclcpp::Node {
     );
     std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>>
         _create_camera_info_subscription(const std::string& topic);
+    std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::PointCloud2>>
+        _create_point_cloud2_subscription(const std::string& topic);
 };

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
@@ -23,6 +23,7 @@ class RerunLoggerNode : public rclcpp::Node {
     void spin();
 
   private:
+    rclcpp::CallbackGroup::SharedPtr _parallel_callback_group;
     std::map<std::string, std::string> _topic_to_entity_path;
     std::map<std::string, std::shared_ptr<rclcpp::SubscriptionBase>> _topic_to_subscription;
     std::map<std::string, std::string> _tf_frame_to_entity_path;

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
@@ -57,6 +57,11 @@ class RerunLoggerNode : public rclcpp::Node {
     void _create_subscriptions();
     void _update_tf();
 
+    void _handle_msg_header(
+        bool restamp, bool lookup_transform, const std::string& entity_path,
+        std_msgs::msg::Header& header
+    );
+
     /* Message specific subscriber factory functions */
     std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Image>> _create_image_subscription(
         const std::string& topic, const TopicOptions& topic_options

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
@@ -18,6 +18,8 @@
 
 #include <rerun.hpp>
 
+using TopicOptions = std::map<std::string, YAML::Node>;
+
 class RerunLoggerNode : public rclcpp::Node {
   public:
     RerunLoggerNode();
@@ -25,16 +27,18 @@ class RerunLoggerNode : public rclcpp::Node {
 
   private:
     rclcpp::CallbackGroup::SharedPtr _parallel_callback_group;
-    std::map<std::string, std::string> _topic_to_entity_path;
     std::map<std::string, std::shared_ptr<rclcpp::SubscriptionBase>> _topic_to_subscription;
     std::map<std::string, std::string> _tf_frame_to_entity_path;
     std::map<std::string, std::string> _tf_frame_to_parent;
-    std::map<std::string, YAML::Node> _topic_options;
+    std::map<std::string, TopicOptions> _raw_topic_options;
     rclcpp::Time _last_tf_update_time;
 
     void _read_yaml_config(std::string yaml_path);
 
-    std::string _resolve_entity_path(const std::string& topic) const;
+    TopicOptions _resolve_topic_options(const std::string& topic, const std::string& message_type)
+        const;
+    std::string _resolve_entity_path(const std::string& topic, const TopicOptions& topic_options)
+        const;
 
     void _add_tf_tree(
         const YAML::Node& node, const std::string& parent_entity_path,
@@ -55,21 +59,27 @@ class RerunLoggerNode : public rclcpp::Node {
 
     /* Message specific subscriber factory functions */
     std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Image>> _create_image_subscription(
-        const std::string& topic
+        const std::string& topic, const TopicOptions& topic_options
     );
     std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::Imu>> _create_imu_subscription(
-        const std::string& topic
+        const std::string& topic, const TopicOptions& topic_options
     );
     std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::PoseStamped>>
-        _create_pose_stamped_subscription(const std::string& topic);
+        _create_pose_stamped_subscription(
+            const std::string& topic, const TopicOptions& topic_options
+        );
     std::shared_ptr<rclcpp::Subscription<tf2_msgs::msg::TFMessage>> _create_tf_message_subscription(
-        const std::string& topic
+        const std::string& topic, const TopicOptions& topic_options
     );
     std::shared_ptr<rclcpp::Subscription<nav_msgs::msg::Odometry>> _create_odometry_subscription(
-        const std::string& topic
+        const std::string& topic, const TopicOptions& topic_options
     );
     std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>>
-        _create_camera_info_subscription(const std::string& topic);
+        _create_camera_info_subscription(
+            const std::string& topic, const TopicOptions& topic_options
+        );
     std::shared_ptr<rclcpp::Subscription<sensor_msgs::msg::PointCloud2>>
-        _create_point_cloud2_subscription(const std::string& topic);
+        _create_point_cloud2_subscription(
+            const std::string& topic, const TopicOptions& topic_options
+        );
 };

--- a/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
+++ b/rerun_bridge/src/rerun_bridge/visualizer_node.hpp
@@ -29,6 +29,7 @@ class RerunLoggerNode : public rclcpp::Node {
     std::map<std::string, std::string> _tf_frame_to_entity_path;
     std::map<std::string, std::string> _tf_frame_to_parent;
     std::map<std::string, YAML::Node> _topic_options;
+    rclcpp::Time _last_tf_update_time;
 
     void _read_yaml_config(std::string yaml_path);
 


### PR DESCRIPTION
This adds
- partial PointCloud2 support (for now limited to x,y,z channels with float),
- optional restamping of message for improved visualization in Rerun when they do not have a proper timestamp,
- multithreading, and
- new Go2 example.

https://github.com/rerun-io/cpp-example-ros2-bridge/assets/9785832/5be16efe-00b4-48dd-9200-14b9db195a1f

