### PR TITLE
Fix ROS 2 dependencies

### DIFF
--- a/rerun_bridge/package.xml
+++ b/rerun_bridge/package.xml
@@ -10,8 +10,7 @@
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>roscpp</depend>
-  <depend>roslib</depend>
+  <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_msgs</depend>


### PR DESCRIPTION
This PR updates the dependencies in package.xml to use ROS 2's `rclcpp` (instead of ROS 1's `roscpp` and `roslib`)