### PR TITLE
Hotfix/go2 example

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -112,7 +112,7 @@ cwd = "humble_ws"
 
 # Install Rerun and URDF loader manually via pip3, this should be replaced with direct pypi dependencies in the future.
 [tasks.rerun_viewer]
-cmd = "pip install rerun-sdk==0.18.2"
+cmd = "pip install rerun-sdk==0.23.4"
 
 [tasks.rerun_urdf_loader]
 cmd = "pip install git+https://github.com/rerun-io/rerun-loader-python-example-urdf.git"

--- a/pixi.toml
+++ b/pixi.toml
@@ -93,7 +93,7 @@ depends_on = ["build"]
 [tasks.go2_ros2_sdk]
 cmd = """
 (test -d src/go2_ros2_sdk || git clone --recurse-submodules https://github.com/abizovnuralem/go2_ros2_sdk.git src/go2_ros2_sdk)
-&& colcon build --packages-select go2_interfaces go2_robot_sdk --cmake-args -DCMAKE_BUILD_TYPE=Release
+&& colcon build --packages-select unitree_go go2_interfaces go2_robot_sdk --cmake-args -DCMAKE_BUILD_TYPE=Release
 """
 cwd = "humble_ws"
 depends_on = ["ws"]

--- a/rerun_bridge/CMakeLists.txt
+++ b/rerun_bridge/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(OpenCV REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.18.2/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.23.4/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
 # setup targets (has to be done before ament_package call)


### PR DESCRIPTION
When running `pixi r go2_example` I got

```
pixi r go2_example
✨ Pixi task (ws): mkdir -p humble_ws/src && ln -sfn $(pwd)/rerun_bridge humble_ws/src/rerun_bridge

✨ Pixi task (build): colcon build --packages-select rerun_bridge --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
Starting >>> rerun_bridge
Finished <<< rerun_bridge [1.75s]

Summary: 1 package finished [1.80s]

✨ Pixi task (go2_example_data): curl -L -C - -O https://storage.googleapis.com/rerun-example-datasets/go2_ros2.zip && unzip go2_ros2.zip
Task 'go2_example_data' can be skipped (cache hit) 🚀

✨ Pixi task (go2_ros2_sdk): (test -d src/go2_ros2_sdk || git clone --recurse-submodules https://github.com/abizovnuralem/go2_ros2_sdk.git src/go2_ros2_sdk)
&& colcon build --packages-select go2_interfaces go2_robot_sdk --cmake-args -DCMAKE_BUILD_TYPE=Release

Starting >>> go2_interfaces
Finished <<< go2_interfaces [0.60s]
Starting >>> go2_robot_sdk
[0.707s] colcon.colcon_ros.task.ament_python.build ERROR Failed to find the following files:
- /home/ags/projects/cpp-example-ros2-bridge/humble_ws/install/unitree_go/share/unitree_go/package.sh
Check that the following packages have been built:
- unitree_go
Failed   <<< go2_robot_sdk [0.00s, exited with code 1]

Summary: 1 package finished [0.66s]
  1 package failed: go2_robot_sdk
```

adding `unitree_go` to the `--packages-select` fixes this.

I also updated rerun to the latest version.